### PR TITLE
Mkdir requires the `-p` argument to not fail on subsequent builds

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -42,7 +42,7 @@ sha512sums=(
 )
 
 build() {
-    mkdir "${srcdir}/build"
+    mkdir -p "${srcdir}/build"
     cd "${srcdir}/FFXIVQuickLauncher-${pkgver}/src/XIVLauncher.Core/"
     dotnet publish -r linux-x64 --sc -o "${srcdir}/build" --configuration Release
 }

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -49,7 +49,7 @@ pkgver() {
 }
 
 build() {
-    mkdir "${srcdir}/build"
+    mkdir -p "${srcdir}/build"
     cd "${srcdir}/FFXIVQuickLauncher/src/XIVLauncher.Core/"
     dotnet publish -r linux-x64 --sc -o "${srcdir}/build" --configuration Release
 }


### PR DESCRIPTION
Without it, subsequent builds fail with:
```
mkdir: cannot create directory '/home/$USER/aur/xivlauncher-git/src/build’: File exists
==> ERROR: A failure occurred in build().
    Aborting...
```