### PR TITLE
Update stable to 1.0.8 via github artifacts

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Vincent Post <cent@spline.de>
 pkgname=xivlauncher
-pkgver=1.0.6
+pkgver=1.0.8
 pkgrel=1
 epoch=1
 pkgdesc="Custom Launcher for Final Fantasy XIV Online (Crossplatform rewrite)"
@@ -9,53 +9,39 @@ url='https://github.com/goatcorp/XIVLauncher.Core'
 license=('GPL')
 depends=(
     'aria2'
-    'sdl2' 'lib32-sdl2'
+    'sdl2' 
     'libsecret'
-    'attr'                  'lib32-attr'
-    'fontconfig'            'lib32-fontconfig'
-    'lcms2'                 'lib32-lcms2'
-    'libxml2'               'lib32-libxml2'
-    'libxcursor'            'lib32-libxcursor'
-    'libxrandr'             'lib32-libxrandr'
-    'libxdamage'            'lib32-libxdamage'
-    'libxi'                 'lib32-libxi'
-    'gettext'               'lib32-gettext'
-    'freetype2'             'lib32-freetype2'
-    'glu'                   'lib32-glu'
-    'libsm'                 'lib32-libsm'
-    'gcc-libs'              'lib32-gcc-libs'
-    'libpcap'               'lib32-libpcap'
-    'faudio'                'lib32-faudio'
-    'desktop-file-utils'    'jxrlib'
+    'desktop-file-utils'
+    'jxrlib'
 )
-makedepends=('dotnet-sdk>=6' 'git')
 optdepends=('steam')
-options=('!strip')
+provides=("xivlauncher=${pkgver}")
+conflicts=(
+        "xivlauncher-git"
+        "xivlauncher-rb"
+)
 source=(
-    "XIVLauncher.Core::git+https://github.com/goatcorp/XIVLauncher.Core.git#tag=${pkgver}"
+    "XIVLauncher.Core.tar.gz::https://github.com/goatcorp/XIVLauncher.Core/releases/download/${pkgver}/XIVLauncher.Core-arch.tar.gz"
+    "512.png::https://raw.githubusercontent.com/goatcorp/XIVLauncher.Core/main/misc/linux_distrib/512.png"
     "XIVLauncher.desktop"
+    "openssl_fix.cnf"
+    "xivlauncher-core"
 )
 sha512sums=(
-    'SKIP'
-    '5ac774f858d4015c59e6758e2a706b93e822bca9c046ed87210deabc141ac101020d2654fbcf8314f9409a4cfcf921d1e26ec0a3b0beab02d1bcd045fb6e6f14'
+    'f1bec7c2b22107dbedab19af9ef2f1c6edff9d4b5b2fb5512a659722cc26416b2a5adf120c90aa8817d5763a50988ef32adaa956e117c2a9e486e2f7e245c8ab'
+    '0c33502cd915132151fa4b6c94899bf3f8806c2943469609cdda09365ff78be863215abd2741048d6c9a934a22dca0f8a8a2c67074c38abc6f67984c393859c4'
+    'd94f652f9571598799fcd9bf87cb7d2e54ca924bc100b73024e81efd0fe9fc12d494f7adc500ff34ed1e53c59f94e1d6f3c5ae29a1c33133cc30988197e46389'
+    'c702d45b607a54716ae3f1c9b0aa548b3226da76b0ae4b8a88e49d16e5117a7ff5164e7dd5b6a2799a16a18d53b2de55a26a87888054c25152df5c4824b38fe0'
+    'dad16da8e1d2bc772f7e1be1f59fd799c596fa88fb77a7e58a94baf10a1ca2f0ad7e79ad3baa8ba24e35dd0bc748884c74371c447816b1ea61098f58a130313a'
 )
-
-prepare() {
-    cd "${srcdir}/XIVLauncher.Core"
-    git submodule update --init --recursive
-}
-
-build() {
-    mkdir -p "${srcdir}/build"
-    cd "${srcdir}/XIVLauncher.Core/src/XIVLauncher.Core/"
-    dotnet publish -r linux-x64 --sc -o "${srcdir}/build" --configuration Release -p:DefineConstants=WINE_XIV_ARCH_LINUX
-}
 
 package() {
     install -d "${pkgdir}/usr/bin/"
     install -d "${pkgdir}/opt/XIVLauncher/"
     install -D -m644 "${srcdir}/XIVLauncher.desktop" "${pkgdir}/usr/share/applications/XIVLauncher.desktop"
-    install -D -m644 "${srcdir}/XIVLauncher.Core/misc/linux_distrib/512.png" "${pkgdir}/usr/share/pixmaps/xivlauncher.png"
-    cp -r "${srcdir}/build/." "${pkgdir}/opt/XIVLauncher/"
+    install -D -m644 "${srcdir}/512.png" "${pkgdir}/usr/share/pixmaps/xivlauncher.png"
+    install -D -m644 "${srcdir}/openssl_fix.cnf" "${pkgdir}/opt/XIVLauncher/openssl_fix.cnf"
+    cp -r "${srcdir}/." "${pkgdir}/opt/XIVLauncher/"
     ln -s ../../opt/XIVLauncher/XIVLauncher.Core "${pkgdir}/usr/bin/XIVLauncher.Core"
+    install -D -m755  "${srcdir}/xivlauncher-core" "${pkgdir}/usr/bin/xivlauncher-core"
 }


### PR DESCRIPTION
Please test this locally before merging/pushing to the AUR in case I made a typo somewhere. I don't currently have an Arch install and this is based on what I do for the MPR (which is just a Debian implementation of the AUR).

Since this is for stable releases that are always tagged, we can skip a bunch of steps by just pulling the binaries already uploaded to GitHub and providing the wrappers needed for OpenSSL and to launch it. This has the bonus of no more build issues from pacman bugs like #13 as well. And it also means updating stable for a new release is as easy as updating the `pkgver` and sha512 for it.

I didn't touch the -git release for now, but as of Wine 8, you can remove all the 32bit packages as Wine finished their WoW64 stuff. That will still be affected by #13 until Arch makes their fix. 